### PR TITLE
Load model only if incoming request is valid.

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -121,12 +121,12 @@ module.exports = cors(
     }
 
     if (req.url === '/api/predict') {
-      const tf = await loadTf()
-      const tfModel = await loadModel()
-
       const { type: mimeType } = contentType.parse(req)
 
       if (CONTENT_TYPES_IMAGE.includes(mimeType)) {
+        const tf = await loadTf()
+        const tfModel = await loadModel()
+        
         const buf = await buffer(req, { limit: '5mb' })
         const { tensor, width, height } = await imgToTensor(buf)
 


### PR DESCRIPTION
Currently, the model is loaded prior to checking whether the incoming request contains an image. Placing those statements in the `if` statement means that those CPU cycles are only run on requests that can be parsed.